### PR TITLE
Fix typo in generate_dict from generate.py

### DIFF
--- a/hardware/generate.py
+++ b/hardware/generate.py
@@ -179,7 +179,7 @@ def generate_dict(model, prefix=_PREFIX):
             for newkey, val in zip(list(_generate_values(key, prefix)),
                                    generate(model[thekey], prefix)):
                 try:
-                    result[newkey] = merge(result[key], val)
+                    result[newkey] = merge(result[newkey], val)
                 except KeyError:
                     result[newkey] = val
         else:


### PR DESCRIPTION
Fix typo in generate_dict from generate.py

```try:
    result[newkey] = merge(result[key], val)
except KeyError:
    result[newkey] = val
```

For exemple with range `=node1-3` the value of key is `node1-3`.
So this key never exist in the `result` array. You always go to KeyError exception.

`result[key]` in `merge` will be replaced by `result[newkey]` (newkey example : node1).