### PR TITLE
Fix typo in generate_dict from generate.py (with tests)

### DIFF
--- a/hardware/generate.py
+++ b/hardware/generate.py
@@ -179,7 +179,7 @@ def generate_dict(model, prefix=_PREFIX):
             for newkey, val in zip(list(_generate_values(key, prefix)),
                                    generate(model[thekey], prefix)):
                 try:
-                    result[newkey] = merge(result[key], val)
+                    result[newkey] = merge(result[newkey], val)
                 except KeyError:
                     result[newkey] = val
         else:

--- a/hardware/tests/test_generate.py
+++ b/hardware/tests/test_generate.py
@@ -15,6 +15,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+from collections import OrderedDict
 import unittest
 
 from hardware import generate
@@ -165,16 +166,18 @@ class TestGenerate(unittest.TestCase):
             )
 
     def test_generate_hosts(self):
-        model = {'=host10-12':
-                 {'=cmdb':
-                  {'gw': ['192.168.1.1', '192.168.1.2'],
-                   '=ip': '192.168.1.10-12'}}}
+        model = OrderedDict([('host10', {'foo': 'bar'}),
+                             ('=host10-12',
+                              {'=cmdb':
+                               {'gw': ['192.168.1.1', '192.168.1.2'],
+                                '=ip': '192.168.1.10-12'}})])
         self.assertEqual(
             generate.generate_dict(model, prefix='='),
             {'host10':
              {'cmdb':
               {'gw': ['192.168.1.1', '192.168.1.2'],
-               'ip': '192.168.1.10'}},
+               'ip': '192.168.1.10'},
+              'foo': 'bar'},
              'host11':
              {'cmdb':
               {'gw': ['192.168.1.1', '192.168.1.2'],


### PR DESCRIPTION
Fix typo in generate_dict from generate.py

```try:
    result[newkey] = merge(result[key], val)
except KeyError:
    result[newkey] = val
```

For exemple with range `=node1-3` the value of key is `node1-3`.
So this key never exist in the `result` array. You always go to KeyError exception.

`result[key]` in `merge` will be replaced by `result[newkey]` (newkey example : node1).