### PR TITLE
Add support for benchmark tests

### DIFF
--- a/hardware/benchmark/__init__.py
+++ b/hardware/benchmark/__init__.py
@@ -1,0 +1,3 @@
+"""
+Module to run benchmark tests for CPU, disks and memory.
+"""

--- a/hardware/benchmark/cpu.py
+++ b/hardware/benchmark/cpu.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2015 Red Hat, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+Benchmark CPU functions.
+"""
+
+import subprocess
+import sys
+
+from hardware.benchmark import utils
+
+
+def run_sysbench_cpu(hw_lst, max_time, cpu_count, processor_num=None):
+    """Running sysbench cpu stress of a give amount of logical cpu.
+
+    :param hw_lst: The hardware inventory list.
+    :param max_time: Limit for total execution time in seconds.
+    :param cpu_count: Number of threads to use for the benchmark.
+    :param processor_num: The CPU number to be tested, if None it
+        will test all CPUs. Defaults to None.
+
+    """
+    taskset = ''
+    if processor_num:
+        sys.stderr.write('Benchmarking CPU %d for %d seconds (%d threads)\n' %
+                         (processor_num, max_time, cpu_count))
+        taskset = 'taskset %s' % hex(1 << processor_num)
+    else:
+        sys.stderr.write('Benchmarking all CPUs for '
+                         '%d seconds (%d threads)\n' % (max_time, cpu_count))
+
+    cmds = ('%s sysbench --max-time=%d --max-requests=10000000'
+            ' --num-threads=%d --test=cpu --cpu-max-prime=15000 run'
+            % (taskset, max_time, cpu_count))
+    sysbench_cmd = subprocess.Popen(cmds, shell=True, stdout=subprocess.PIPE)
+
+    for line in sysbench_cmd.stdout:
+        if "total number of events" in line:
+            line_ = line.rstrip('\n').replace(' ', '')
+            _, perf = line_.split(':')
+
+            value = str(int(int(perf) / max_time))
+            if processor_num:
+                hw_lst.append(('cpu',
+                               'logical_%d' % processor_num,
+                               'loops_per_sec', value))
+            else:
+                hw_lst.append(('cpu', 'logical', 'loops_per_sec', value))
+
+
+def search_cpuinfo(processor_num, item):
+    """Search for information about a given CPU."""
+    cpuinfo = open('/proc/cpuinfo', 'r')
+    found = False
+    for line in cpuinfo:
+        if line.strip():
+            values = line.rstrip('\n').split(':')
+            if "processor" in values[0] and int(values[1]) == processor_num:
+                found = True
+            if (item in values[0]) and (found is True):
+                return values[1].replace(' ', '')
+    cpuinfo.close()
+    return None
+
+
+def get_bogomips(hw_lst, processor_num):
+    """Get the number og bogomips of a given CPU."""
+    bogo = search_cpuinfo(processor_num, "bogomips")
+    if bogo is not None:
+        hw_lst.append(('cpu', 'logical_%d' % processor_num, 'bogomips', bogo))
+
+
+def get_cache_size(hw_lst, processor_num):
+    """Get the cache size of a given CPU."""
+    cache_size = search_cpuinfo(processor_num, "cache size")
+    if cache_size is not None:
+        hw_lst.append(('cpu', 'logical_%d' % processor_num,
+                       'cache_size', cache_size))
+
+
+def cpu_perf(hw_lst, max_time=10, burn_test=False):
+    """Perform CPU's performance test.
+
+    :param hw_lst: The hardware inventory list.
+    :param max_time: Limit for total execution time in seconds.
+        Defaults to 10.
+    :param burn_test: Boolean value. Whether to perform a burn
+        test. Defaults to False.
+
+    """
+    logical = utils.get_value(hw_lst, 'cpu', 'logical', 'number')
+    physical = utils.get_value(hw_lst, 'cpu', 'physical', 'number')
+
+    # Individual Test aren't useful for burn_test
+    if burn_test is False:
+        if physical is not None:
+            sys.stderr.write('CPU Performance: %d logical '
+                             'CPU to test (ETA: %d seconds)\n'
+                             % (int(physical),
+                                (int(physical) + 1) * max_time))
+            for processor_num in utils.get_one_cpu_per_socket(hw_lst):
+                get_bogomips(hw_lst, processor_num)
+                get_cache_size(hw_lst, processor_num)
+                run_sysbench_cpu(hw_lst, max_time, 1, processor_num)
+    else:
+        sys.stderr.write('CPU Burn: %d logical'
+                         ' CPU to test (ETA: %d seconds)\n' % (
+                             int(logical), max_time))
+
+    run_sysbench_cpu(hw_lst, max_time, int(logical))

--- a/hardware/benchmark/disk.py
+++ b/hardware/benchmark/disk.py
@@ -1,0 +1,179 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2015 Red Hat, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+Benchmark Disk functions.
+"""
+
+import os
+import re
+import subprocess
+import sys
+
+
+# NOTE(lucasagomes): The amount of time a specified workload will run before
+# logging any performance numbers. Useful for letting performance settle
+# before logging results, thus minimizing the runtime required for stable
+# results. Note that the ramp_time is considered lead in time for a job,
+# thus it will increase the total runtime if a special timeout or runtime
+# is specified.
+RAMP_TIME = 5
+
+
+def is_booted_storage_device(disk):
+    """Check if a given disk is booted."""
+    cmdline = "grep -w /ahcexport /proc/mounts | cut -d ' ' -f 1 "
+    "| sed -e 's/[0-9]*//g'"
+    if '/dev/' not in disk:
+        disk = '/dev/%s' % disk
+    grep_cmd = subprocess.Popen(cmdline,
+                                shell=True, stdout=subprocess.PIPE)
+    for booted_disk in grep_cmd.stdout:
+        booted_disk = booted_disk.rstrip('\n').strip()
+        if booted_disk == disk:
+            return True
+    return False
+
+
+def get_disks_name(hw_lst, without_bootable=False):
+    """Get a list of disk names."""
+    disks = []
+    for entry in hw_lst:
+        if entry[0] == 'disk' and entry[2] == 'size':
+            if without_bootable and is_booted_storage_device(entry[1]):
+                sys.stderr.write("Skipping disk %s in destructive mode, "
+                                 "this is the booted device !\n" % entry[1])
+            elif 'I:' in entry[1]:
+                pass
+            else:
+                disks.append(entry[1])
+    return disks
+
+
+def run_fio(hw_lst, disks_list, mode, io_size, time, rampup_time):
+    """Run the 'fio' benchmark tool."""
+    filelist = [f for f in os.listdir(".") if f.endswith(".fio")]
+    for myfile in filelist:
+        os.remove(myfile)
+    fio = ("fio --ioengine=libaio --invalidate=1 --ramp_time=%d --iodepth=32 "
+           "--runtime=%d --time_based --direct=1 "
+           "--bs=%s --rw=%s" % (rampup_time, time, io_size, mode))
+
+    global_disk_list = ''
+    for disk in disks_list:
+        if '/dev/' not in disk:
+            disk = '/dev/%s' % disk
+        # Flusing Disk's cache prior benchmark
+        os.system("hdparm -f %s >/dev/null 2>&1" % disk)
+        short_disk = disk.replace('/dev/', '')
+        fio = "%s --name=MYJOB-%s --filename='%s'" % (fio, short_disk, disk)
+        global_disk_list += '%s,' % short_disk
+    global_disk_list = global_disk_list.rstrip(',')
+    sys.stderr.write(
+        'Benchmarking storage %s for %s seconds in '
+        '%s mode with blocksize=%s\n' %
+        (global_disk_list, time, mode, io_size))
+    fio_cmd = subprocess.Popen(fio,
+                               shell=True, stdout=subprocess.PIPE)
+    current_disk = ''
+    for line in fio_cmd.stdout:
+        if ('MYJOB-' in line) and ('pid=' in line):
+            # MYJOB-sda: (groupid=0, jobs=1): err= 0: pid=23652: Mon Sep  9
+            # 16:21:42 2013
+            current_disk = re.search('MYJOB-(.*): \(groupid', line).group(1)
+            continue
+        if ("read : io=" in line) or ("write: io=" in line):
+            # read : io=169756KB, bw=16947KB/s, iops=4230, runt= 10017msec
+            if (len(disks_list) > 1):
+                mode_str = "simultaneous_%s_%s" % (mode, io_size)
+            else:
+                mode_str = "standalone_%s_%s" % (mode, io_size)
+
+            try:
+                perf = re.search('bw=(.*?B/s),', line).group(1)
+            except Exception:
+                sys.stderr.write('Failed at detecting '
+                                 'bwps pattern with %s\n' % line)
+            else:
+                multiply = 1
+                divide = 1
+                if "MB/s" in perf:
+                    multiply = 1024
+                elif "KB/s" in perf:
+                    multiply = 1
+                elif "B/s" in perf:
+                    divide = 1024
+                try:
+                    iperf = perf.replace(
+                        'KB/s', '').replace('MB/s', '').replace('B/s', '')
+                except Exception:
+                    True
+
+                value = str(int(float(float(iperf) * multiply / divide)))
+                hw_lst.append(('disk', current_disk, mode_str + '_KBps',
+                               value))
+
+            try:
+                value = re.search('iops=(.*),', line).group(1).strip(' ')
+                hw_lst.append(('disk', current_disk, mode_str + '_IOps',
+                               value))
+            except Exception:
+                sys.stderr.write('Failed at detecting iops '
+                                 'pattern with %s\n' % line)
+
+
+def disk_perf(hw_lst, destructive=False, running_time=10):
+    """Reporting disk performance."""
+    mode = "non destructive"
+    # Let's count the number of runs in safe mode
+    disks = get_disks_name(hw_lst)
+    disks_num = len(disks)
+    total_runtime = disks_num * (running_time + RAMP_TIME) * 2
+    if disks_num > 1:
+        total_runtime += 2 * (running_time + RAMP_TIME)
+
+    if destructive:
+        total_runtime = total_runtime * 2
+        mode = 'destructive'
+
+    sys.stderr.write('Running storage bench on %d disks in'
+                     ' %s mode for %d seconds\n' %
+                     (disks_num, mode, total_runtime))
+    for disk in disks:
+        is_booted_storage_device(disk)
+        if destructive:
+            if is_booted_storage_device(disk):
+                sys.stderr.write("Skipping disk %s in destructive mode,"
+                                 " this is the booted device !" % disk)
+            else:
+                run_fio(hw_lst, ['%s' % disk], "write", "1M",
+                        running_time, RAMP_TIME)
+                run_fio(hw_lst, ['%s' % disk], "randwrite", "4k",
+                        running_time, RAMP_TIME)
+
+        run_fio(hw_lst, ['%s' % disk],
+                "read", "1M", running_time, RAMP_TIME)
+        run_fio(hw_lst, ['%s' % disk],
+                "randread", "4k", running_time, RAMP_TIME)
+
+    if (disks_num > 1):
+        if destructive:
+            run_fio(hw_lst, get_disks_name(hw_lst, True),
+                    "write", "1M", running_time, RAMP_TIME)
+            run_fio(hw_lst, get_disks_name(hw_lst, True),
+                    "randwrite", "4k", running_time, RAMP_TIME)
+        run_fio(hw_lst, disks, "read", "1M", running_time, RAMP_TIME)
+        run_fio(hw_lst, disks, "randread", "4k", running_time, RAMP_TIME)

--- a/hardware/benchmark/mem.py
+++ b/hardware/benchmark/mem.py
@@ -1,0 +1,164 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2015 Red Hat, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+Benchmark Memory functions.
+"""
+
+import re
+import subprocess
+import sys
+
+import psutil
+
+from hardware.benchmark import utils
+
+
+def get_available_memory():
+    """Get the amount of available memory."""
+    try:
+        return psutil.virtual_memory().total
+    except Exception:
+        return psutil.avail_phymem()
+
+
+def check_mem_size(block_size, cpu_count):
+    """Check if a test can run with a given block size and cpu count."""
+    dsplit = re.compile(r'\d+')
+    ssplit = re.compile(r'[A-Z]+')
+    unit = ssplit.findall(block_size)
+    unit_in_bytes = 1
+    if unit[0] == 'K':
+        unit_in_bytes = 1024
+    elif unit[0] == 'M':
+        unit_in_bytes = 1024 * 1024
+    elif unit[0] == 'G':
+        unit_in_bytes = 1024 * 1024 * 1024
+
+    size_in_bytes = (unit_in_bytes * int(dsplit.findall(block_size)[0])
+                     * cpu_count)
+    if (size_in_bytes > get_available_memory()):
+        return False
+
+    return True
+
+
+def run_sysbench_memory_threaded(hw_lst, max_time, block_size, cpu_count,
+                                 processor_num=None):
+    """Running memtest on a processor."""
+    check_mem = check_mem_size(block_size, cpu_count)
+    taskset = ''
+    if processor_num:
+        if check_mem is False:
+            msg = ("Avoid Benchmarking memory @%s "
+                   "from CPU %d, not enough memory\n")
+            sys.stderr.write(msg % (block_size, processor_num))
+            return
+
+        sys.stderr.write('Benchmarking memory @%s from CPU %d'
+                         ' for %d seconds (%d threads)\n' %
+                         (block_size, processor_num, max_time, cpu_count))
+        taskset = 'taskset %s' % hex(1 << processor_num)
+    else:
+        if check_mem is False:
+            msg = ("Avoid Benchmarking memory @%s "
+                   "from all CPUs, not enough memory\n")
+            sys.stderr.write(msg % block_size)
+            return
+        sys.stderr.write('Benchmarking memory @%s from all CPUs '
+                         'for %d seconds (%d threads)\n'
+                         % (block_size, max_time, cpu_count))
+
+    _cmd = ('%s sysbench --max-time=%d --max-requests=100000000 '
+            '--num-threads=%d --test=memory --memory-block-size=%s run')
+    sysbench_cmd = subprocess.Popen(_cmd % (taskset, max_time,
+                                            cpu_count, block_size),
+                                    shell=True, stdout=subprocess.PIPE)
+
+    for line in sysbench_cmd.stdout:
+        if "transferred" in line:
+            _, right = line.rstrip('\n').replace(' ', '').split('(')
+            perf, _ = right.split('.')
+            if processor_num:
+                hw_lst.append(('cpu',
+                               'logical_%d' % processor_num,
+                               'bandwidth_%s' % block_size,
+                               perf))
+            else:
+                hw_lst.append(('cpu', 'logical',
+                               'threaded_bandwidth_%s' % block_size,
+                               perf))
+
+
+def run_sysbench_memory_forked(hw_lst, max_time, block_size, cpu_count):
+    """Running forked memtest on a processor."""
+    if check_mem_size(block_size, cpu_count) is False:
+        cmd = ('Avoid benchmarking memory @%s from all'
+               ' CPUs (%d forked processes), not enough memory\n')
+        sys.stderr.write(cmd % (block_size, cpu_count))
+        return
+    sys.stderr.write('Benchmarking memory @%s from all CPUs'
+                     ' for %d seconds (%d forked processes)\n'
+                     % (block_size, max_time, cpu_count))
+    sysbench_cmd = '('
+    for _ in range(cpu_count):
+        _cmd = ('sysbench --max-time=%d --max-requests=100000000 '
+                '--num-threads=1 --test=memory --memory-block-size=%s run &')
+        sysbench_cmd += _cmd % (max_time, block_size)
+
+    sysbench_cmd.rstrip('&')
+    sysbench_cmd += ')'
+
+    global_perf = 0
+    process = subprocess.Popen(
+        sysbench_cmd, shell=True, stdout=subprocess.PIPE)
+    for line in process.stdout:
+        if "transferred" in line:
+            _, right = line.rstrip('\n').replace(' ', '').split('(')
+            perf, _ = right.split('.')
+            global_perf += int(perf)
+
+    hw_lst.append(('cpu', 'logical', 'forked_bandwidth_%s' %
+                   (block_size), str(global_perf)))
+
+
+def mem_perf(hw_lst, max_time=5):
+    """Report the memory performance."""
+    all_cpu_testing_time = 5
+    block_size_list = ['1K', '4K', '1M', '16M', '128M', '1G', '2G']
+    logical = utils.get_value(hw_lst, 'cpu', 'logical', 'number')
+    physical = utils.get_value(hw_lst, 'cpu', 'physical', 'number')
+    if physical:
+        eta = int(physical) * len(block_size_list) * max_time
+        eta += 2 * (all_cpu_testing_time * len(block_size_list))
+        sys.stderr.write('Memory Performance: %d logical CPU'
+                         ' to test (ETA: %d seconds)\n'
+                         % (int(physical), int(eta)))
+        for cpu_nb in utils.get_one_cpu_per_socket(hw_lst):
+            for block_size in block_size_list:
+                run_sysbench_memory_threaded(hw_lst, max_time,
+                                             block_size, 1, cpu_nb)
+
+        # There is not need to test fork vs thread
+        #  if only a single logical cpu is present
+        if int(logical) > 1:
+            for block_size in block_size_list:
+                run_sysbench_memory_threaded(hw_lst, all_cpu_testing_time,
+                                             block_size, int(logical))
+
+            for block_size in block_size_list:
+                run_sysbench_memory_forked(hw_lst, all_cpu_testing_time,
+                                           block_size, int(logical))

--- a/hardware/benchmark/utils.py
+++ b/hardware/benchmark/utils.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2015 Red Hat, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+Benchmark utility functions.
+"""
+
+import subprocess
+
+
+def get_value(hw_lst, level1, level2, level3):
+    """Get an specific value from the hardware inventory."""
+    for entry in hw_lst:
+        if level1 == entry[0] and level2 == entry[1] and level3 == entry[2]:
+            return entry[3]
+    return None
+
+
+def get_one_cpu_per_socket(hw_lst):
+    """Return a list of physical CPU ids."""
+    logical = get_value(hw_lst, 'cpu', 'logical', 'number')
+    current_phys_package_id = -1
+    cpu_list = []
+    for processor_num in range(int(logical)):
+        cmdline = ("cat /sys/devices/system/cpu/cpu%d/topology"
+                   "/physical_package_id" % int(processor_num))
+        phys_cmd = subprocess.Popen(cmdline,
+                                    shell=True, stdout=subprocess.PIPE)
+        for phys_str in phys_cmd.stdout:
+            phys_id = int(phys_str.strip())
+            if phys_id > current_phys_package_id:
+                current_phys_package_id = phys_id
+                cpu_list.append(current_phys_package_id)
+    return cpu_list

--- a/hardware/tests/test_benchmark_cpu.py
+++ b/hardware/tests/test_benchmark_cpu.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2015 Red Hat, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import subprocess
+import unittest
+
+import mock
+
+from hardware.benchmark import cpu
+from hardware.benchmark import utils
+
+
+SYSBENCH_OUTPUT = """Test execution summary:
+    total time:                          10.0012s
+    total number of events:              1234
+    total time taken by event execution: 9.9994
+    per-request statistics:
+         min:                                  1.53ms
+         avg:                                  1.70ms
+         max:                                  5.02ms
+         approx.  95 percentile:               2.29ms
+
+Threads fairness:
+    events (avg/stddev):           5893.0000/0.00
+    execution time (avg/stddev):   9.9994/0.00""".splitlines()
+
+
+@mock.patch.object(cpu, 'search_cpuinfo')
+@mock.patch.object(utils, 'get_one_cpu_per_socket')
+@mock.patch.object(subprocess, 'Popen')
+class TestBenchmarkCPU(unittest.TestCase):
+
+    def setUp(self):
+        super(TestBenchmarkCPU, self).setUp()
+        self.hw_data = [('cpu', 'logical', 'number', 2),
+                        ('cpu', 'physical', 'number', 2)]
+
+    def test_cpu_perf(self, mock_popen, mock_cpu_socket, mock_search_info):
+        mock_cpu_socket.return_value = range(2)
+        mock_search_info.side_effect = ('fake-bogomips1', 'fake-cache1',
+                                        'fake-bogomips2', 'fake-cache2')
+        cpu.cpu_perf(self.hw_data)
+        expected = [
+            ('cpu', 'logical', 'number', 2),
+            ('cpu', 'physical', 'number', 2),
+            ('cpu', 'logical_0', 'bogomips', 'fake-bogomips1'),
+            ('cpu', 'logical_0', 'cache_size', 'fake-cache1'),
+            ('cpu', 'logical_1', 'bogomips', 'fake-bogomips2'),
+            ('cpu', 'logical_1', 'cache_size', 'fake-cache2')
+        ]
+        self.assertEqual(sorted(expected), sorted(self.hw_data))
+        expected = [mock.call(0, "bogomips"),
+                    mock.call(0, "cache size"),
+                    mock.call(1, "bogomips"),
+                    mock.call(1, "cache size")]
+        mock_search_info.assert_has_calls(expected)
+
+    def test_get_bogomips(self, mock_popen, mock_cpu_socket, mock_search_info):
+        mock_search_info.return_value = 'fake-bogomips'
+        hw_data = []
+        cpu.get_bogomips(hw_data, 0)
+
+        self.assertEqual([('cpu', 'logical_0', 'bogomips', 'fake-bogomips')],
+                         hw_data)
+        mock_search_info.assert_called_once_with(0, 'bogomips')
+
+    def test_get_cache_size(self, mock_popen, mock_cpu_socket,
+                            mock_search_info):
+        mock_search_info.return_value = 'fake-cache'
+        hw_data = []
+        cpu.get_cache_size(hw_data, 0)
+        self.assertEqual([('cpu', 'logical_0', 'cache_size', 'fake-cache')],
+                         hw_data)
+        mock_search_info.assert_called_once_with(0, 'cache size')
+
+    def test_run_sysbench_cpu(self, mock_popen, mock_cpu_socket,
+                              mock_search_info):
+        mock_popen.return_value = mock.Mock(stdout=SYSBENCH_OUTPUT)
+        hw_data = []
+        cpu.run_sysbench_cpu(hw_data, 10, 1)
+        mock_popen.assert_called_once_with(' sysbench --max-time=10 '
+                                           '--max-requests=10000000 '
+                                           '--num-threads=1 --test=cpu '
+                                           '--cpu-max-prime=15000 run',
+                                           shell=True, stdout=subprocess.PIPE)
+        self.assertEqual([('cpu', 'logical', 'loops_per_sec', '123')], hw_data)

--- a/hardware/tests/test_benchmark_disk.py
+++ b/hardware/tests/test_benchmark_disk.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2015 Red Hat, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import subprocess
+import unittest
+
+import mock
+
+from hardware.benchmark import disk
+
+
+FIO_OUTPUT_READ = """MYJOB-fake-disk: (groupid=0, jobs=1): err= 0: pid=5427:
+  read : io=123456KB, bw=123456KB/s, iops=123, runt= 10304msec""".splitlines()
+
+
+@mock.patch.object(subprocess, 'Popen')
+class TestBenchmarkDisk(unittest.TestCase):
+
+    def setUp(self):
+        super(TestBenchmarkDisk, self).setUp()
+        self.hw_data = [('disk', 'fake-disk', 'size', '10'),
+                        ('disk', 'fake-disk2', 'size', '15')]
+
+    def test_disk_perf(self, mock_popen):
+        mock_popen.return_value = mock.Mock(stdout=FIO_OUTPUT_READ)
+        disk.disk_perf(self.hw_data)
+
+        expected = [
+            ('disk', 'fake-disk', 'size', '10'),
+            ('disk', 'fake-disk2', 'size', '15'),
+            ('disk', 'fake-disk', 'standalone_read_1M_KBps', '123456'),
+            ('disk', 'fake-disk', 'standalone_read_1M_IOps', '123'),
+            ('disk', 'fake-disk', 'standalone_randread_4k_KBps', '123456'),
+            ('disk', 'fake-disk', 'standalone_randread_4k_IOps', '123'),
+            ('disk', 'fake-disk', 'standalone_read_1M_KBps', '123456'),
+            ('disk', 'fake-disk', 'standalone_read_1M_IOps', '123'),
+            ('disk', 'fake-disk', 'standalone_randread_4k_KBps', '123456'),
+            ('disk', 'fake-disk', 'standalone_randread_4k_IOps', '123'),
+            ('disk', 'fake-disk', 'simultaneous_read_1M_KBps', '123456'),
+            ('disk', 'fake-disk', 'simultaneous_read_1M_IOps', '123'),
+            ('disk', 'fake-disk', 'simultaneous_randread_4k_KBps', '123456'),
+            ('disk', 'fake-disk', 'simultaneous_randread_4k_IOps', '123')
+        ]
+        self.assertEqual(sorted(expected), sorted(self.hw_data))
+
+    def test_get_disks_name(self, mock_popen):
+        result = disk.get_disks_name(self.hw_data)
+        self.assertEqual(sorted(['fake-disk', 'fake-disk2']), sorted(result))
+
+    def test_run_fio(self, mock_popen):
+        mock_popen.return_value = mock.Mock(stdout=FIO_OUTPUT_READ)
+        hw_data = []
+        disks_list = ['fake-disk', 'fake-disk2']
+        disk.run_fio(hw_data, disks_list, "read", 123, 10, 5)
+
+        self.assertEqual(sorted(
+            [('disk', 'fake-disk', 'simultaneous_read_123_KBps', '123456'),
+             ('disk', 'fake-disk', 'simultaneous_read_123_IOps', '123')]),
+            sorted(hw_data))

--- a/hardware/tests/test_benchmark_mem.py
+++ b/hardware/tests/test_benchmark_mem.py
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2015 Red Hat, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import subprocess
+import unittest
+
+import mock
+
+from hardware.benchmark import mem
+from hardware.benchmark import utils
+
+
+SYSBENCH_OUTPUT = """Operations performed: 1957354 (391412.04 ops/sec)
+
+1911.48 MB transferred (382.24 MB/sec)
+
+
+Test execution summary:
+    total time:                          5.0008s
+    total number of events:              1957354
+    total time taken by event execution: 3.0686
+    per-request statistics:
+         min:                                  0.00ms
+         avg:                                  0.00ms
+         max:                                  0.23ms
+         approx.  95 percentile:               0.00ms
+
+Threads fairness:
+    events (avg/stddev):           1957354.0000/0.00
+    execution time (avg/stddev):   3.0686/0.00""".splitlines()
+
+
+@mock.patch.object(mem, 'get_available_memory')
+@mock.patch.object(utils, 'get_one_cpu_per_socket')
+@mock.patch.object(subprocess, 'Popen')
+class TestBenchmarkMem(unittest.TestCase):
+
+    def setUp(self):
+        super(TestBenchmarkMem, self).setUp()
+        self.hw_data = [('cpu', 'logical', 'number', 2),
+                        ('cpu', 'physical', 'number', 2)]
+
+    def test_mem_perf(self, mock_popen, mock_cpu_socket, mock_get_memory):
+        mock_get_memory.return_value = 123456789012
+        mock_popen.return_value = mock.Mock(stdout=SYSBENCH_OUTPUT)
+        mock_cpu_socket.return_value = range(2)
+        mem.mem_perf(self.hw_data)
+
+        expected = [
+            ('cpu', 'logical', 'number', 2),
+            ('cpu', 'physical', 'number', 2),
+            ('cpu', 'logical', 'threaded_bandwidth_1K', '382'),
+            ('cpu', 'logical', 'threaded_bandwidth_4K', '382'),
+            ('cpu', 'logical', 'threaded_bandwidth_1M', '382'),
+            ('cpu', 'logical', 'threaded_bandwidth_16M', '382'),
+            ('cpu', 'logical', 'threaded_bandwidth_128M', '382'),
+            ('cpu', 'logical', 'threaded_bandwidth_1G', '382'),
+            ('cpu', 'logical', 'threaded_bandwidth_2G', '382'),
+            ('cpu', 'logical_1', 'bandwidth_1K', '382'),
+            ('cpu', 'logical_1', 'bandwidth_4K', '382'),
+            ('cpu', 'logical_1', 'bandwidth_1M', '382'),
+            ('cpu', 'logical_1', 'bandwidth_16M', '382'),
+            ('cpu', 'logical_1', 'bandwidth_128M', '382'),
+            ('cpu', 'logical_1', 'bandwidth_1G', '382'),
+            ('cpu', 'logical_1', 'bandwidth_2G', '382'),
+            ('cpu', 'logical', 'threaded_bandwidth_1K', '382'),
+            ('cpu', 'logical', 'threaded_bandwidth_4K', '382'),
+            ('cpu', 'logical', 'threaded_bandwidth_1M', '382'),
+            ('cpu', 'logical', 'threaded_bandwidth_16M', '382'),
+            ('cpu', 'logical', 'threaded_bandwidth_128M', '382'),
+            ('cpu', 'logical', 'threaded_bandwidth_1G', '382'),
+            ('cpu', 'logical', 'threaded_bandwidth_2G', '382'),
+            ('cpu', 'logical', 'forked_bandwidth_1K', '382'),
+            ('cpu', 'logical', 'forked_bandwidth_4K', '382'),
+            ('cpu', 'logical', 'forked_bandwidth_1M', '382'),
+            ('cpu', 'logical', 'forked_bandwidth_16M', '382'),
+            ('cpu', 'logical', 'forked_bandwidth_128M', '382'),
+            ('cpu', 'logical', 'forked_bandwidth_1G', '382'),
+            ('cpu', 'logical', 'forked_bandwidth_2G', '382')
+        ]
+        self.assertEqual(sorted(expected), sorted(self.hw_data))
+
+    def test_check_mem_size(self, mock_popen, mock_cpu_socket,
+                            mock_get_memory):
+        block_size_list = ('1K', '4K', '1M', '16M', '128M', '1G', '2G')
+
+        mock_get_memory.return_value = 123456789012
+        for block_size in block_size_list:
+            self.assertTrue(mem.check_mem_size(block_size, 2))
+
+        # Low memory
+        mock_get_memory.return_value = 1
+        for block_size in block_size_list:
+            self.assertFalse(mem.check_mem_size(block_size, 2))
+
+    def test_run_sysbench_memory_forked(self, mock_popen, mock_cpu_socket,
+                                        mock_get_memory):
+        mock_get_memory.return_value = 123456789012
+        mock_popen.return_value = mock.Mock(stdout=SYSBENCH_OUTPUT)
+
+        hw_data = []
+        mem.run_sysbench_memory_forked(hw_data, 10, '1K', 2)
+        self.assertEqual([('cpu', 'logical', 'forked_bandwidth_1K', '382')],
+                         hw_data)
+
+    def test_run_sysbench_memory_threaded(self, mock_popen, mock_cpu_socket,
+                                          mock_get_memory):
+        mock_get_memory.return_value = 123456789012
+        mock_popen.return_value = mock.Mock(stdout=SYSBENCH_OUTPUT)
+
+        hw_data = []
+        mem.run_sysbench_memory_threaded(hw_data, 10, '1K', 2)
+        self.assertEqual([('cpu', 'logical', 'threaded_bandwidth_1K', '382')],
+                         hw_data)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pbr>=0.8.2,<1.0
 Babel>=1.3
 netaddr
 pexpect
+psutil


### PR DESCRIPTION
This patch is adding support for benchmark tests as part of the
hardware-detect tool.

The test is optional and can be activated by passing the --benchmark
parameter to the tool. The parameter supports passing multiple values,
acceptable values right now are "disk", "cpu" and "mem".

Another parameter --benchmark-disk-destructive have been added and if
set it will turn on the destructive mode for the disk benchmark.

The new help menu:

usage: hardware-detect [-h] [-H] [--benchmark component [component ...]]
                       [--benchmark-disk-destructive]

optional arguments:
  -h, --help            show this help message and exit
  -H, --human           Print output in human readable format
  --benchmark component [component ...], -b component [component ...]
                        Run benchmark for specific components. Valid
                        components are: disk, cpu, mem
  --benchmark-disk-destructive
                        If specified make the disk component benchmark
			to be destructive