### PR TITLE
hardware/state.py: remove none mac

### DIFF
--- a/hardware/state.py
+++ b/hardware/state.py
@@ -255,14 +255,9 @@ Need to call unlock to release the lock.
                             nics.append({"mac": db[var]})
                         else:
                             print('cmdb setting %s not found' % var)
-                            nics.append({"mac": 'none'})
                     else:
                         nics.append({"mac": info['mac']})
-                else:
-                    nics.append({"mac": 'none'})
                 info = {}
-            else:
-                nics.append({"mac": 'none'})
         return nics
 
     def hardware_info(self, hostname):

--- a/hardware/tests/test_state.py
+++ b/hardware/tests/test_state.py
@@ -82,9 +82,7 @@ class TestState(unittest.TestCase):
                                           {'size': '19Gi'},
                                           {'size': '20Gi'}],
                                 'nics': [{'mac': 'dd:ee:ff'},
-                                         {'mac': 'aa:bb:cc'},
-                                         {'mac': 'none'},
-                                         {'mac': 'none'}],
+                                         {'mac': 'aa:bb:cc'}],
                                 'memory': 8192,
                                 'ncpus': 4})
 


### PR DESCRIPTION
When a mac address is not provided by the cmdb
this commit make hardware_info to not add
a 'none' value.