### PR TITLE
Remove the psutil dependency

### DIFF
--- a/hardware/benchmark/mem.py
+++ b/hardware/benchmark/mem.py
@@ -22,17 +22,15 @@ import re
 import subprocess
 import sys
 
-import psutil
-
 from hardware.benchmark import utils
 
 
 def get_available_memory():
-    """Get the amount of available memory."""
-    try:
-        return psutil.virtual_memory().total
-    except Exception:
-        return psutil.avail_phymem()
+    """Return the total amount of available memory, in bytes."""
+    with open('/proc/meminfo', 'r') as f:
+        for line in f:
+            if line.startswith('MemFree:'):
+                return int(line.split()[1]) * 1024
 
 
 def check_mem_size(block_size, cpu_count):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ pbr>=0.8.2,<1.0
 Babel>=1.3
 netaddr
 pexpect
-psutil


### PR DESCRIPTION
psutil was used just to get the amount of available memory in the system,
psutil makes it nice to be able to do it in multiple platforms like bsd,
linux and windows. But since we only run this code on linux we can get
this information directly from /proc/meminfo so that we don't need to
add an extra dependency.