### PR TITLE
Add CLI client to run cardiff against Ironic DB

### DIFF
--- a/hardware/cardiff/check.py
+++ b/hardware/cardiff/check.py
@@ -121,7 +121,7 @@ def print_detail(detail_options, details, df, matched_category):
     if (utils.print_level & utils.Levels.DETAIL) != utils.Levels.DETAIL:
         return
     if len(df.loc[details]) > 0:
-        print()
+        print("")
         print("%-34s: %-8s: %s" % (matched_category[0],
                                    utils.Levels.message[utils.print_level],
                                    detail_options['item']))
@@ -188,7 +188,7 @@ def network_perf(systems, unique_id, group_number, detail_options,
         matched_category = []
         for net in df.transpose().columns:
             if have_net_data is False:
-                print()
+                print("")
                 print("Group %d : Checking network disks perf" % group_number)
                 have_net_data = True
             consistent = []
@@ -250,7 +250,7 @@ def logical_disks_perf(systems, unique_id, group_number, detail_options,
         matched_category = []
         for disk in df.transpose().columns:
             if have_disk_data is False:
-                print()
+                print("")
                 print("Group %d : Checking logical disks perf" % group_number)
                 have_disk_data = True
             consistent = []
@@ -545,7 +545,7 @@ def cpu_perf(systems, unique_id, group_number, detail_options,
 
         for cpu in df.transpose().columns:
             if have_cpu_data is False:
-                print()
+                print("")
                 print("Group %d : Checking CPU perf" % group_number)
                 have_cpu_data = True
             print_perf(2, 7, df.transpose()[cpu], df, mode, cpu, consistent,
@@ -645,7 +645,7 @@ def memory_perf(systems, unique_id, group_number, detail_options,
         df = DataFrame(results)
         for memory in df.transpose().columns:
             if have_memory_data is False:
-                print()
+                print("")
                 print("Group %d : Checking Memory perf" % group_number)
                 have_memory_data = True
 

--- a/hardware/cardiff/compare_sets.py
+++ b/hardware/cardiff/compare_sets.py
@@ -60,7 +60,7 @@ def print_systems_groups(systems_groups):
         print("Group %d (%d Systems)" % (
             systems_groups.index(system), len(system)))
         print("-> " + ', '.join(system))
-        print()
+        print("")
 
 
 def print_groups(global_params, result, title):
@@ -87,7 +87,7 @@ def print_groups(global_params, result, title):
         if "output_dir" in global_params.keys():
             with open("%s.def" % group_name, "w") as fout:
                 pprint.pprint(sorted(eval(element)), fout)
-        print()
+        print("")
 
     if "output_dir" in global_params.keys():
         if len(result) > 1:

--- a/hardware/cardiff/ironic.py
+++ b/hardware/cardiff/ironic.py
@@ -1,0 +1,132 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+import sys
+
+from hardware.cardiff import cardiff
+from hardware.cardiff import compare_sets
+from hardware.cardiff import utils
+
+
+def get_facts(client):
+    nodes = client.node.list(detail=True)
+    # cardiff expects data in the form of a list of nodes
+    # where each node is represented by a list of tuples
+    # with each tuple representing a fact about the node
+    try:
+        facts = [[tuple(fact) for fact in node.extra['edeploy_facts']] for
+                 node in nodes]
+    except KeyError:
+        err_msg = ("You must run introspection on the nodes before "
+                   "running this tool.\n")
+        sys.stderr.write(err_msg)
+        sys.exit(1)
+    return facts
+
+
+def get_ironic_client(args):
+    try:
+        from ironicclient import client
+        from ironicclient.exc import AmbiguousAuthSystem
+    except ImportError:
+        err_msg = ("The python-ironicclient module is not installed or not "
+                   "on the python path.\nThis module is required to use this "
+                   "tool.\n")
+        sys.stderr.write(err_msg)
+        sys.exit(2)
+
+    # This section gets an ironic client.
+    # TODO(trown): refactor to include error handling, and inputing
+    #              credentials on the command line. Might also want
+    #              getpass for password input.
+    kwargs = {'os_password': os.environ.get('OS_PASSWORD'),
+              'os_username': os.environ.get('OS_USERNAME'),
+              'os_tenant_name': os.environ.get('OS_TENANT_NAME'),
+              'os_auth_url': os.environ.get('OS_AUTH_URL')}
+    try:
+        ironic = client.get_client(1, **kwargs)
+    except AmbiguousAuthSystem:
+        err_msg = ("You must source a keystonerc file in order to use "
+                   "this tool.\n")
+        sys.stderr.write(err_msg)
+        sys.exit(3)
+
+    return ironic
+
+
+def print_report(args, facts):
+    # The global_params are only used for a single output_dir key.
+    # The output_dir key is not currently useful for this use case.
+    # We could probably refactor hardware to make it a kwarg, so we don't need
+    # to pass an empty dictionary.
+    global_params = {}
+    # The detail dictionary has three keys (group, category, item). This is
+    # only used in the case that we have the print_level set to
+    # utils.Levels.DETAIL
+    # This is not currently used, but required by the architecture of hardware.
+    detail = {'group': '', 'category': '', 'item': ''}
+    # We have a different kernel cmdline for each system, so we have to ignore
+    # system to get groups that have more than one system.
+    ignore_list = 'system'
+    # unique_id can either be 'serial' or 'uuid', in virtual environments
+    # 'serial' is not reported so we default to 'uuid'
+    unique_id = args.unique_id
+    # Extract the host list from the data to get the initial list of hosts.
+    systems_groups = []
+    systems_groups.append(utils.get_hosts_list(facts, unique_id))
+    # Print the group information
+    if args.groups or args.full:
+        compare_sets.print_systems_groups(systems_groups)
+
+    # Print the category information
+    if args.categories or args.full:
+        cardiff.group_systems(global_params, facts, unique_id,
+                              systems_groups, ignore_list)
+
+    # Print the outlier information
+    if args.outliers or args.full:
+        cardiff.compare_performance(facts, unique_id, systems_groups, detail)
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Consume benchmark data '
+                                                 'from Ironic.')
+    parser.add_argument('-f', '--full', action='store_true',
+                        help='Print the full report.')
+    parser.add_argument('-g', '--groups', action='store_true',
+                        help='Print the groupings by similar hardware.')
+    parser.add_argument('-c', '--categories', action='store_true',
+                        help='Print the report for each category.')
+    parser.add_argument('-o', '--outliers', action='store_true',
+                        help='Print the report showing outliers.')
+    parser.add_argument('-u', '--unique-id', dest='unique_id',
+                        action='store', default='uuid',
+                        choices=['uuid', 'serial'],
+                        help='Unique key to identify the nodes by.')
+    args = parser.parse_args()
+
+    # If we did not pass any print arguments, print the help and exit
+    if not (args.groups or args.categories or args.outliers or args.full):
+        print("\nYou did not specify anything to print.\n")
+        parser.print_help()
+        sys.exit(4)
+
+    ironic = get_ironic_client(args)
+    facts = get_facts(ironic)
+
+    print_report(args, facts)
+
+if __name__ == '__main__':
+    main()

--- a/hardware/tests/test_cardiff_ironic.py
+++ b/hardware/tests/test_cardiff_ironic.py
@@ -1,0 +1,134 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import sys
+import unittest
+
+from hardware.cardiff import cardiff
+from hardware.cardiff import compare_sets
+from hardware.cardiff import ironic
+from hardware.cardiff import utils
+
+from ironicclient.exc import AmbiguousAuthSystem
+import mock
+
+
+@mock.patch.object(ironic, 'get_ironic_client', autospec=True)
+class TestGetFacts(unittest.TestCase):
+    def test_facts(self, client_mock):
+        node1 = mock.Mock(extra={'edeploy_facts':
+                                 [[u'cpu', u'logical_0',
+                                   u'bogomips', u'4199.99'],
+                                  [u'cpu', u'logical_0',
+                                   u'cache_size', u'4096KB']
+                                  ]})
+        node2 = mock.Mock(extra={'edeploy_facts':
+                                 [[u'cpu', u'logical_0',
+                                   u'bogomips', u'4098.99'],
+                                  [u'cpu', u'logical_0',
+                                   u'cache_size', u'4096KB']
+                                  ]})
+        client = client_mock.return_value
+        client.node.list.return_value = [node1, node2]
+        expected = [[(u'cpu', u'logical_0', u'bogomips', u'4199.99'),
+                     (u'cpu', u'logical_0', u'cache_size', u'4096KB')],
+                    [(u'cpu', u'logical_0', u'bogomips', u'4098.99'),
+                     (u'cpu', u'logical_0', u'cache_size', u'4096KB')]]
+        facts = ironic.get_facts(client)
+        self.assertEqual(facts, expected)
+
+    def test_no_facts(self, client_mock):
+        node1 = mock.Mock(extra={})
+        node2 = mock.Mock(extra={})
+        client = client_mock.return_value
+        client.node.list.return_value = [node1, node2]
+        self.assertRaisesRegexp(SystemExit, "1", ironic.get_facts, client)
+
+
+class TestGetIronicClient(unittest.TestCase):
+    def test_no_ironicclient_module(self):
+        ic_mock = mock.Mock(spec='meow')
+        modules = {'ironicclient': ic_mock}
+        module_patcher = mock.patch.dict('sys.modules', modules)
+        module_patcher.start()
+        self.assertRaisesRegexp(SystemExit, "2", ironic.get_ironic_client, {})
+        module_patcher.stop()
+
+    def test_no_credentials(self):
+        ic_mock = mock.Mock()
+        modules = {
+            'ironicclient': ic_mock,
+            'ironicclient.client': ic_mock.client
+        }
+        ic_mock.client.get_client.side_effect = AmbiguousAuthSystem
+        module_patcher = mock.patch.dict('sys.modules', modules)
+        module_patcher.start()
+        self.assertRaisesRegexp(SystemExit, "3", ironic.get_ironic_client, {})
+        module_patcher.stop()
+
+
+@mock.patch.object(utils, 'get_hosts_list', autospec=True)
+@mock.patch.object(compare_sets, 'print_systems_groups', autospec=True)
+@mock.patch.object(cardiff, 'group_systems', autospec=True)
+@mock.patch.object(cardiff, 'compare_performance', autospec=True)
+class TestPrintReport(unittest.TestCase):
+    def setUp(self):
+        self.args = mock.Mock()
+        self.args.groups = False
+        self.args.full = False
+        self.args.categories = False
+        self.args.outliers = False
+        self.args.unique_id = 'uuid'
+        self.facts = []
+        self.detail = {'group': '', 'category': '', 'item': ''}
+
+    def test_groups(self, cp_mock, gs_mock, psg_mock, ghl_mock):
+        self.args.groups = True
+        ghl_mock.return_value = []
+        ironic.print_report(self.args, self.facts)
+        ghl_mock.assert_called_once_with([], 'uuid')
+        psg_mock.assert_called_once_with([[]])
+        self.assertItemsEqual(cp_mock.call_args_list, [])
+        self.assertItemsEqual(gs_mock.call_args_list, [])
+
+    def test_categories(self, cp_mock, gs_mock, psg_mock, ghl_mock):
+        self.args.categories = True
+        ghl_mock.return_value = []
+        ironic.print_report(self.args, self.facts)
+        ghl_mock.assert_called_once_with([], 'uuid')
+        gs_mock.assert_called_once_with({}, self.facts, 'uuid', [[]], 'system')
+        self.assertItemsEqual(cp_mock.call_args_list, [])
+        self.assertItemsEqual(psg_mock.call_args_list, [])
+
+    def test_outliers(self, cp_mock, gs_mock, psg_mock, ghl_mock):
+        self.args.outliers = True
+        ghl_mock.return_value = []
+        ironic.print_report(self.args, self.facts)
+        ghl_mock.assert_called_once_with([], 'uuid')
+        cp_mock.assert_called_once_with([], 'uuid', [[]], self.detail)
+        self.assertItemsEqual(psg_mock.call_args_list, [])
+        self.assertItemsEqual(gs_mock.call_args_list, [])
+
+    def test_full(self, cp_mock, gs_mock, psg_mock, ghl_mock):
+        self.args.full = True
+        ghl_mock.return_value = []
+        ironic.print_report(self.args, self.facts)
+        ghl_mock.assert_called_once_with([], 'uuid')
+        psg_mock.assert_called_once_with([[]])
+        gs_mock.assert_called_once_with({}, self.facts, 'uuid', [[]], 'system')
+        cp_mock.assert_called_once_with([], 'uuid', [[]], self.detail)
+
+
+class TestMain(unittest.TestCase):
+    def test_no_args(self):
+        sys.argv = ["ironic-cardiff"]
+        self.assertRaisesRegexp(SystemExit, "4", ironic.main)

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,3 +46,4 @@ output_file = hardware/locale/hardware.pot
 console_scripts =
     hardware-detect = hardware.detect:main
     hardware-cardiff = hardware.cardiff.cardiff:main
+    ironic-cardiff = hardware.cardiff.ironic:main

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -14,3 +14,4 @@ testrepository>=0.0.18
 testscenarios>=0.4
 testtools>=0.9.34
 pylint==1.4.1
+python-ironicclient>=0.5.0


### PR DESCRIPTION
Adds a client that will fetch the benchmark data from the Ironic
database and run cardiff against it. Also, changed the empty print
statements to include an empty string. Otherwise, "()" was printed
to the screen.