### PR TITLE
Fix empty print statements

### DIFF
--- a/hardware/cardiff/cardiff.py
+++ b/hardware/cardiff/cardiff.py
@@ -191,7 +191,7 @@ def analyze_data(global_params, pattern, ignore_list, detail, rampup_value=0,
     compare_performance(bench_values, unique_id, systems_groups, detail,
                         rampup_value, current_dir)
     print("##########################################")
-    print()
+    print("")
     return bench_values
 
 

--- a/hardware/cardiff/check.py
+++ b/hardware/cardiff/check.py
@@ -121,7 +121,7 @@ def print_detail(detail_options, details, df, matched_category):
     if (utils.print_level & utils.Levels.DETAIL) != utils.Levels.DETAIL:
         return
     if len(df.loc[details]) > 0:
-        print()
+        print("")
         print("%-34s: %-8s: %s" % (matched_category[0],
                                    utils.Levels.message[utils.print_level],
                                    detail_options['item']))
@@ -188,7 +188,7 @@ def network_perf(systems, unique_id, group_number, detail_options,
         matched_category = []
         for net in df.transpose().columns:
             if have_net_data is False:
-                print()
+                print("")
                 print("Group %d : Checking network disks perf" % group_number)
                 have_net_data = True
             consistent = []
@@ -250,7 +250,7 @@ def logical_disks_perf(systems, unique_id, group_number, detail_options,
         matched_category = []
         for disk in df.transpose().columns:
             if have_disk_data is False:
-                print()
+                print("")
                 print("Group %d : Checking logical disks perf" % group_number)
                 have_disk_data = True
             consistent = []
@@ -545,7 +545,7 @@ def cpu_perf(systems, unique_id, group_number, detail_options,
 
         for cpu in df.transpose().columns:
             if have_cpu_data is False:
-                print()
+                print("")
                 print("Group %d : Checking CPU perf" % group_number)
                 have_cpu_data = True
             print_perf(2, 7, df.transpose()[cpu], df, mode, cpu, consistent,
@@ -645,7 +645,7 @@ def memory_perf(systems, unique_id, group_number, detail_options,
         df = DataFrame(results)
         for memory in df.transpose().columns:
             if have_memory_data is False:
-                print()
+                print("")
                 print("Group %d : Checking Memory perf" % group_number)
                 have_memory_data = True
 

--- a/hardware/cardiff/compare_sets.py
+++ b/hardware/cardiff/compare_sets.py
@@ -60,7 +60,7 @@ def print_systems_groups(systems_groups):
         print("Group %d (%d Systems)" % (
             systems_groups.index(system), len(system)))
         print("-> " + ', '.join(system))
-        print()
+        print("")
 
 
 def print_groups(global_params, result, title):
@@ -87,7 +87,7 @@ def print_groups(global_params, result, title):
         if "output_dir" in global_params.keys():
             with open("%s.def" % group_name, "w") as fout:
                 pprint.pprint(sorted(eval(element)), fout)
-        print()
+        print("")
 
     if "output_dir" in global_params.keys():
         if len(result) > 1:

--- a/hardware/megacli.py
+++ b/hardware/megacli.py
@@ -142,19 +142,19 @@ if __name__ == "__main__":
 
         encs = enc_info(ctrl_num)
 
-        print()
+        print("")
 
         print('Enclosing:')
         pprint.pprint(encs)
 
         for enc in encs:
             for disk_num in range(enc['NumberOfPhysicalDrives']):
-                print()
+                print("")
                 print('Physical disk', disk_num)
                 pprint.pprint(pdinfo(ctrl_num, enc['DeviceId'], disk_num))
 
         for ld_num in range(ld_get_num(ctrl_num)):
-            print()
+            print("")
             print('Logical disk', ld_num)
             pprint.pprint(ld_get_info(ctrl_num, ld_num))
 


### PR DESCRIPTION
This patch changes all 'print()' statements to 'print("")'.
Without the empty string, this was printing '()' instead of the
intended empty line.